### PR TITLE
feat(sensors): add SGP30 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sgp30",
  "shared-bus",
  "thingbuf",
  "tinymetrics",
@@ -1531,6 +1532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sensirion-i2c"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f8a8f52f850f281f9faebd9dc09d68caa29d6ce1dfd3806686b316258768d6"
+dependencies = [
+ "embedded-hal 0.2.7",
+]
+
+[[package]]
 name = "sensor-scd30"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1600,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sgp30"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b61c13de51a42068f72dd59c5252b8b479fbed3b52d9bd1365ef18c97bbf4bb"
+dependencies = [
+ "byteorder",
+ "embedded-hal 0.2.7",
+ "num-traits",
+ "sensirion-i2c",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tinymetrics = { git = "https://github.com/hawkw/tinymetrics", default-features =
     "std",
 ]}
 pmsa003i = { path = "pmsa003i" }
+sgp30 = "0.3.1"
 
 [build-dependencies]
 embuild = "0.31.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,13 +29,20 @@ format][prom].
   > isn't present on the I<sup>2</sup>C bus. of course, if you're missing a
   > particular sensor, you won't be collecting the data it measures :)
 
-  + **[Sensirion SCD30][scd30] NDIR CO<sup>2</sup> sensor** (with temperature
+  + **[Sensirion SCD30][scd30] NDIR CO<sub>2</sub> sensor** (with temperature
     and relative humidity).
   + **[Bosch BME680][bme680] temperature, barometric pressure, humidity, and
     VOC** (MOX gas sensor). i meant to get the slightly newer BME688 breakout
     but i clicked the wrong one. a BME688 would also work.
   + **[Plantower PMSA003I][pmsa003i] particulate matter sensor**, measuring
     particulate matter concetrations.
+  + **[Sensirion SGP30][sgp30] tVOC sensor**: this sensor measures total
+    volatile organic compounds (tVOC). it also calculates an equivalent
+    CO<sub>2</sub> (eCO<sub>2</sub>) measurement based on the tVOC measurement.
+    in my experience, these eCO<sub>2</sub> numbers are *wildly* different from
+    the "real" CO<sub>2</sub> measurements provided by a sensor like the SCD30.
+    i wouldn't treat them as an authoritative measurement of CO<sub>2</sub>
+    concentration, but they might still be interesting
   + **more sensors coming soon!** there are several different I<sup>2</sup>C
     air quality sensors, and even more different temperature/pressure/humidity
     sensors, on the market. eventually, i'd like to add drivers for most of the
@@ -55,6 +62,7 @@ format][prom].
 [scd30]: https://www.adafruit.com/product/4867
 [bme680]: https://www.adafruit.com/product/3660
 [pmsa003i]: https://www.adafruit.com/product/4632
+[sgp30]: https://www.adafruit.com/product/3709
 [TCA4307]: https://www.adafruit.com/product/5159
 [stemmaqt]: https://learn.adafruit.com/introducing-adafruit-stemma-qt/what-is-stemma-qt
 

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -9,7 +9,7 @@ pub struct Pmsa003i<I> {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Reading {
-    /// Particulate concentrations in µg/𝑚3.
+    /// Particulate concentrations in µg/𝑚³.
     pub concentrations: Concentrations,
 
     /// Counts of particles of various diameters in 0.1L of air.
@@ -19,38 +19,38 @@ pub struct Reading {
     pub sensor_version: u8,
 }
 
-/// Particulate concentrations in µg/𝑚3.
+/// Particulate concentrations in µg/㎥.
 ///
 /// This is a separate struct from [`ParticleCounts`] so that they can have
 /// separate [`fmt::Display`] implementations.
 #[derive(Copy, Clone, Debug)]
 pub struct Concentrations {
-    /// PM1.0 concentration in µg/𝑚3, under environmental atmospheric
+    /// PM1.0 concentration in µg/𝑚³, under environmental atmospheric
     /// conditions.
     ///
     /// *Note*: I don't actually know what "under atmospheric environment" means
     /// but it says that in the datasheet. I am guessing this refers to humidity
     /// compensation?
     pub pm1_0: u16,
-    /// PM1.0 concentration in µg/𝑚3, under standard atmospheric conditions.
+    /// PM1.0 concentration in µg/𝑚³, under standard atmospheric conditions.
     pub pm1_0_standard: u16,
 
-    /// PM2.5 concentration in µg/𝑚3, under environmental atmospheric
+    /// PM2.5 concentration in µg/𝑚³, under environmental atmospheric
     /// conditions.
     ///
     /// Note: I don't actually know what "under atmospheric environment" means
     /// but it says that in the datasheet...
     pub pm2_5: u16,
-    /// PM2.5 concentration in µg/𝑚3, under standard atmospheric conditions.
+    /// PM2.5 concentration in µg/𝑚³, under standard atmospheric conditions.
     pub pm2_5_standard: u16,
 
-    /// PM10.0 concentration in µg/𝑚3, under environmental atmospheric
+    /// PM10.0 concentration in µg/𝑚³, under environmental atmospheric
     /// conditions.
     ///
     /// Note: I don't actually know what "under atmospheric environment" means
     /// but it says that in the datasheet...
     pub pm10_0: u16,
-    /// PM10.0 concentration in µg/𝑚3, under standard atmospheric conditions.
+    /// PM10.0 concentration in µg/𝑚³, under standard atmospheric conditions.
     pub pm10_0_standard: u16,
 }
 
@@ -66,7 +66,7 @@ pub struct ParticleCounts {
     pub particles_0_5um: u16,
     /// Number of particles with diameter >= 1.0 µm in 0.1L of air.
     pub particles_1_0um: u16,
-    /// Number of particles with diameter >= 2.5 µm in 0.1L of air.
+    /// Number of particles with diameter >= 2.5 µ𝑚 in 0.1L of air.
     pub particles_2_5um: u16,
     /// Number of particles with diameter >= 5.0 µm in 0.1L of air.
     pub particles_5_0um: u16,
@@ -209,7 +209,7 @@ impl fmt::Display for Reading {
 // === impl Concentrations ===
 
 impl Concentrations {
-    pub const UNIT: &str = "µg/𝑚3";
+    pub const UNIT: &str = "µg/𝑚³";
 }
 
 impl fmt::Display for Concentrations {
@@ -252,7 +252,7 @@ impl ParticleCounts {
 impl fmt::Display for ParticleCounts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         const UNIT: &str = ParticleCounts::UNIT;
-        const UM: &str = "µm";
+        const UM: &str = "µ𝑚";
         let Self {
             particles_0_3um,
             particles_0_5um,

--- a/src/bme680.rs
+++ b/src/bme680.rs
@@ -68,13 +68,13 @@ impl Sensor for Bme680 {
         let pressure = pressure / 100f32;
         // TODO(eliza): since we also know the pressure we could skip some of
         // this hairy floating-point calculation...
-        let abs_humidity = crate::units::absolute_humidity(temperature as f64, humidity as f64);
+        let abs_humidity = crate::units::absolute_humidity(temperature, humidity);
         log::info!("[BME680]: Pressure: {pressure:>3.3} hPa, Temp: {temperature:>3.3} \
             \u{00B0}C, Humidity: {abs_humidity:>3.3} g/𝑚³ ({humidity:>3.3}%)");
         self.pressure_gauge.set_value(pressure.into());
         self.temp_gauge.set_value(temperature.into());
         self.rel_humidity_gauge.set_value(humidity.into());
-        self.abs_humidity_gauge.set_value(abs_humidity);
+        self.abs_humidity_gauge.set_value(abs_humidity.into());
         if let Some(gas) = gas_resistance {
             log::info!("[BME680]: Gas resistance: {gas:>3.3} \u{2126}");
             self.gas_resistance_gauge.set_value(gas.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@ pub mod net;
 pub mod pmsa003i;
 pub mod retry;
 pub mod scd30;
+pub mod sgp30;
 pub mod sensor;
 pub mod ws2812;
+pub mod units;
 
 pub type I2cRef<'bus> = shared_bus::I2cProxy<'bus, SharedI2c>;
 pub type I2cBus = shared_bus::BusManager<SharedI2c>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // If using the `binstart` feature of `esp-idf-sys`, always keep this module
 // imported
 use anyhow::Context;
-use eclss::{actor, bme680::Bme680, http, net, pmsa003i::Pmsa003i, scd30::Scd30, sensor, ws2812};
+use eclss::{actor, bme680::Bme680, http, net, pmsa003i::Pmsa003i, scd30::Scd30, sgp30::Sgp30, sensor, ws2812};
 use embassy_time::Duration;
 use esp_idf_hal::{
     i2c::{I2cConfig, I2cDriver},
@@ -97,6 +97,12 @@ fn main() -> anyhow::Result<()> {
         let (tx, rx) = actor::channel(10);
         exec.spawn_local_collect(sensor_mangler.run::<Bme680>(rx), &mut tasks)
             .context("failed to spawn BME680 task")?;
+        tx
+    };
+    let _sgp30_control = {
+        let (tx, rx) = actor::channel(10);
+        exec.spawn_local_collect(sensor_mangler.run::<Sgp30>(rx), &mut tasks)
+            .context("failed to spawn SCD30 task")?;
         tx
     };
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -11,7 +11,9 @@ pub struct SensorMetrics {
     #[serde(serialize_with = "serialize_metric")]
     pub temp: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
-    pub co2: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
+    pub co2: GaugeFamily<'static, 2, SensorLabel>,
+    #[serde(serialize_with = "serialize_metric")]
+    pub eco2: GaugeFamily<'static, 2, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
     pub rel_humidity: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
@@ -48,7 +50,11 @@ impl SensorMetrics {
             co2: MetricBuilder::new("co2_ppm")
                 .with_help("CO2 in parts per million (ppm).")
                 .with_unit("ppm")
-                .build_labeled::<_, SensorLabel, 4>(),
+                .build_labeled::<_, SensorLabel, 2>(),
+            eco2: MetricBuilder::new("eco2_ppm")
+                .with_help("VOC equivalent CO2 (eCO2) calculated by a tVOC sensor, in parts per million (ppm).")
+                .with_unit("ppm")
+                .build_labeled::<_, SensorLabel, 2>(),
             rel_humidity: MetricBuilder::new("humidity_percent")
                 .with_help("Relative humidity (RH) percentage.")
                 .with_unit("percent")

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -13,11 +13,15 @@ pub struct SensorMetrics {
     #[serde(serialize_with = "serialize_metric")]
     pub co2: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
-    pub humidity: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
+    pub rel_humidity: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
+    #[serde(serialize_with = "serialize_metric")]
+    pub abs_humidity: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
     pub pressure: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
     pub gas_resistance: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
+    #[serde(serialize_with = "serialize_metric")]
+    pub tvoc: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
     pub pm_conc: GaugeFamily<'static, 3, DiameterLabel>,
     #[serde(serialize_with = "serialize_metric")]
@@ -45,9 +49,13 @@ impl SensorMetrics {
                 .with_help("CO2 in parts per million (ppm).")
                 .with_unit("ppm")
                 .build_labeled::<_, SensorLabel, 4>(),
-            humidity: MetricBuilder::new("humidity_percent")
+            rel_humidity: MetricBuilder::new("humidity_percent")
                 .with_help("Relative humidity (RH) percentage.")
                 .with_unit("percent")
+                .build_labeled::<_, SensorLabel, 4>(),
+            abs_humidity: MetricBuilder::new("absolute_humidity_grams_m3")
+                .with_help("Absolute humidity in grams per cubic meter.")
+                .with_unit("g/m^3")
                 .build_labeled::<_, SensorLabel, 4>(),
             pressure: MetricBuilder::new("pressure_hpa")
                 .with_help("Barometric pressure, in hectopascals (hPa).")
@@ -56,6 +64,10 @@ impl SensorMetrics {
             gas_resistance: MetricBuilder::new("gas_resistance_ohms")
                 .with_help("BME680 VOC sensor resistance, in Ohms.")
                 .with_unit("Ohms")
+                .build_labeled::<_, SensorLabel, 4>(),
+            tvoc: MetricBuilder::new("tvoc_ppb")
+                .with_help("Total Volatile Organic Compounds (VOC) in parts per billion (ppb)")
+                .with_unit("ppb")
                 .build_labeled::<_, SensorLabel, 4>(),
             pm_conc: MetricBuilder::new("pm_concentration_ug_m3")
                 .with_help("Particulate matter concentration in ug/m^3")
@@ -74,7 +86,7 @@ impl SensorMetrics {
     pub fn fmt_metrics(&self, f: &mut impl fmt::Write) -> fmt::Result {
         self.temp.fmt_metric(f)?;
         self.co2.fmt_metric(f)?;
-        self.humidity.fmt_metric(f)?;
+        self.rel_humidity.fmt_metric(f)?;
         self.pressure.fmt_metric(f)?;
         self.gas_resistance.fmt_metric(f)?;
         self.sensor_errors.fmt_metric(f)?;

--- a/src/scd30.rs
+++ b/src/scd30.rs
@@ -93,11 +93,11 @@ impl Sensor for Scd30 {
         let sensor_scd30::Measurement { co2, temp, rh } = self
             .sensor
             .read_data()
-            .map_err(|err| anyhow!("error reading data: {err:?}"))?; 
-        let abs_humidity = crate::units::absolute_humidity(temp as f64, rh as f64);
+            .map_err(|err| anyhow!("error reading data: {err:?}"))?;
+        let abs_humidity = crate::units::absolute_humidity(temp, rh);
         self.co2_gauge.set_value(co2.into());
         self.rel_humidity_gauge.set_value(rh.into());
-        self.abs_humidity_gauge.set_value(abs_humidity);
+        self.abs_humidity_gauge.set_value(abs_humidity.into());
         self.temp_gauge.set_value(temp.into());
         log::info!("CO2: {co2:>8.3} ppm, Temp: {temp:>3.3} \u{00B0}C, Humidity: {abs_humidity:>3.3} g/𝑚³ ({rh:>3.3}%)");
 

--- a/src/sgp30.rs
+++ b/src/sgp30.rs
@@ -1,0 +1,88 @@
+use crate::{metrics::Gauge, sensor::Sensor, I2cBus, I2cRef, SensorMetrics};
+use esp_idf_hal::delay::Ets;
+use anyhow::anyhow;
+use std::time::Instant;
+use embassy_time::Duration;
+
+pub struct Sgp30 {
+    sensor: sgp30::Sgp30<I2cRef<'static>, Ets>,
+    co2_gauge: &'static Gauge,
+    tvoc_gauge: &'static Gauge,
+    started_at: Instant,
+    init_measurements: usize,
+}
+
+const NAME: &'static str = "SGP30";
+impl Sensor for Sgp30 {
+    type ControlMessage = ();
+
+    const NAME: &'static str = NAME;
+
+    fn bringup(busman: &'static I2cBus, metrics: &'static SensorMetrics) -> anyhow::Result<Self> {
+        // the adafruit breakout board has this I2C address.
+        const ADDR: u8 = 0x58;
+
+        log::info!("connecting to {NAME}...");
+        let i2c = busman.acquire_i2c();
+        let mut sensor = sgp30::Sgp30::new(i2c, ADDR, Ets);
+
+        let version = sensor.get_feature_set().map_err(|error| anyhow!("failed to get {NAME} feature set: {error:?}"))?;
+        log::info!("connected to {NAME}: version: {version:?}");
+
+        // run the self-test
+        let selftest = sensor.selftest().map_err(|error| anyhow!("failed to run {NAME} self-test: {error:?}"))?;
+        if !selftest {
+            anyhow::bail!("{NAME} self-test failed");
+        }
+
+        // initialize the sensor.
+        sensor.init().map_err(|error| anyhow!("failed to initialize {NAME}: {error:?}"))?;
+
+        Ok(Self {
+            sensor,
+            co2_gauge: metrics.co2.register(Self::LABEL).unwrap(),
+            tvoc_gauge: metrics.tvoc.register(Self::LABEL).unwrap(),
+            init_measurements: 0,
+            started_at: Instant::now(),
+
+        })
+    }
+
+    fn poll(&mut self) -> anyhow::Result<()> {
+        let sgp30::Measurement { tvoc_ppb, co2eq_ppm } = self.sensor.measure()
+            .map_err(|error| anyhow!("failed to read {NAME} measurement: {error:?}"))?;
+
+        // the SGP30 has a 15-second initialization phase after startup, during which it
+        // calibrates itself. while the sensor is initializing, all measurements will
+        // read 400 ppm eCO2 and 0 ppb tVOC. we don't want to report these values, so
+        // track how long has elapsed since the sensor has initialized, and throw out
+        // measurements until the init phase is done.
+        if self.init_measurements <= 15 {
+            let elapsed = self.started_at.elapsed();
+            log::info!("[{NAME}] in init phase for {elapsed:?} ({} measurements)...", self.init_measurements);
+            self.init_measurements += 1;
+                // ignore the measurement until we have exited the
+                // initialization phase
+            return Ok(());
+        }
+
+        log::info!("[{NAME}] eCO2: {co2eq_ppm} ppm, tVOC: {tvoc_ppb} ppb");
+
+        self.co2_gauge.set_value(co2eq_ppm as f64);
+        self.tvoc_gauge.set_value(tvoc_ppb as f64);
+        Ok(())
+    }
+
+    fn poll_interval(&self) -> Duration {
+        // per https://docs.rs/sgp30/latest/sgp30/index.html#doing-measurements,
+        // the sensor MUST be polled every second, or else its dynamic baseline
+        // calibration thingy gets messed up. per the datasheet, doing a reading
+        // takes 12 ms, so the actual poll interval is less than 1 second.
+        Duration::from_secs(1) - Duration::from_millis(12)
+    }
+
+    fn handle_control_message(&mut self, _: &Self::ControlMessage) -> anyhow::Result<()> {
+        // TODO(eliza): calibrate with absolute humidity?
+        anyhow::bail!("not yet implemented")
+    }
+}

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,6 +1,7 @@
 /// Given a temperature in Celcius and a relative humidity percentage, returns
 /// an absolute humidity in grams/m^3.
-pub fn absolute_humidity(temp_c: f64, rel_humidity_percent: f64) -> f64 {
+// TODO(eliza): can we avoid some of the float math?
+pub fn absolute_humidity(temp_c: f32, rel_humidity_percent: f32) -> f32 {
     // first, determine the saturation vapor pressure (`P_sat`) at `temp_c`
     // degrees --- the pressure when the relative humidity is 100%. we compute
     // this using a variant of the Magnus-Tetens formula:
@@ -17,9 +18,10 @@ pub fn absolute_humidity(temp_c: f64, rel_humidity_percent: f64) -> f64 {
     // see https://carnotcycle.wordpress.com/2012/08/04/how-to-convert-relative-humidity-to-absolute-humidity/
 }
 
+
 #[cfg(test)]
 mod tests {
-    const TEST_EPSILON: f64 = 0.5; // it's an approximation lol
+    const TEST_EPSILON: f32 = 0.5; // it's an approximation lol
     use super::*;
     macro_rules! assert_float_eq {
         ($a:expr, $b:expr) => {

--- a/src/units.rs
+++ b/src/units.rs
@@ -18,6 +18,9 @@ pub fn absolute_humidity(temp_c: f32, rel_humidity_percent: f32) -> f32 {
     // see https://carnotcycle.wordpress.com/2012/08/04/how-to-convert-relative-humidity-to-absolute-humidity/
 }
 
+// calculate absolute humidity every 5 polls, to avoid expensive floating point
+// math.
+pub(crate) const ABS_HUMIDITY_INTERVAL: usize = 5;
 
 #[cfg(test)]
 mod tests {

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,0 +1,42 @@
+/// Given a temperature in Celcius and a relative humidity percentage, returns
+/// an absolute humidity in grams/m^3.
+pub fn absolute_humidity(temp_c: f64, rel_humidity_percent: f64) -> f64 {
+    // first, determine the saturation vapor pressure (`P_sat`) at `temp_c`
+    // degrees --- the pressure when the relative humidity is 100%. we compute
+    // this using a variant of the Magnus-Tetens formula:
+    // (see https://doi.org/10.1175/1520-0493(1980)108%3C1046:TCOEPT%3E2.0.CO;2)
+    let p_sat = 6.112 * ((17.64 * temp_c) / (temp_c + 243.5)).exp();
+    // using `P_sat`, the pressure at 100% RH, we can compute `P`, the pressure
+    // at the given relative humidity percentage, by multiplying:
+    //     P = P_sat * (rel_humidity_percent / 100)
+    // knowing the pressure, we then multiply `P` by the molecular weight
+    // of water (18.02) to give the absolute humidity in grams/m^3.
+    //
+    // this calculation simplifies to:
+    (p_sat * rel_humidity_percent * 2.1674) / (273.15 + temp_c)
+    // see https://carnotcycle.wordpress.com/2012/08/04/how-to-convert-relative-humidity-to-absolute-humidity/
+}
+
+#[cfg(test)]
+mod tests {
+    const TEST_EPSILON: f64 = 0.5; // it's an approximation lol
+    use super::*;
+    macro_rules! assert_float_eq {
+        ($a:expr, $b:expr) => {
+            let a = dbg!($a);
+            let b = $b;
+            assert!((a - b).abs() < TEST_EPSILON, "{a} != {b} (~{TEST_EPSILON}")
+        }
+    }
+
+    // shoutout to the wonderful table from Wikipedia for a giant pile of
+    // test values:
+    // https://en.wikipedia.org/wiki/Humidity#Relationship_between_absolute-,_relative-humidity,_and_temperature
+    #[test]
+    fn absolute_humidity_50_c() {
+        assert_float_eq!(absolute_humidity(50.0, 0.0), 0.0);
+        assert_float_eq!(absolute_humidity(50.0, 10.0), 8.3);
+        assert_float_eq!(absolute_humidity(50.0, 20.0), 16.7);
+        assert_float_eq!(absolute_humidity(50.0, 30.0), 24.9);
+    }
+}


### PR DESCRIPTION
This branch adds support for the SGP30 VOC sensor. It also updates the
code for humidity sensors to calculate absolute humidity, as well as
relative humidity, as this is needed to calibrate the SGP30. Absolute
humidity is also exposed as a new metric.